### PR TITLE
fix: (re)read pipewire nodes if empty

### DIFF
--- a/src/main/java/io/github/katacc/AudioController.java
+++ b/src/main/java/io/github/katacc/AudioController.java
@@ -299,9 +299,6 @@ public class AudioController {
 
     /**
      * getId to get id of a application from pw-dump
-     * Problem is that its really slow to generate the dump and parse the json
-     * Therefore only get the updated id's every 100 midi messages.
-     *
      * */
     public List<Integer> getId(String name) {
 


### PR DESCRIPTION
pw-dump was only executed on pw-mixer start. so pipewire nodes had be active pw-mixer start to be recognized.

so

1. start pw-mixer
2. start google chrome

resulted in the fader for google chrome not working

this pr fixes this by re-reading the config if idX.isEmpty()